### PR TITLE
Generate fields based on Model name Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Run the commande line
 ```bash
 php artisan nova-resource-fields:generate
 ```
-:::tip Model Name
-if your model within `app` folder, you can just set Model Name only without full namespace
-:::
+> if your model within `app` folder, you can just set Model Name only without full namespace
+
 And then just answer to the questions and copy the result.
 ## Comming soon
 Include more elements like relationships...

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Run the commande line
 ```bash
 php artisan nova-resource-fields:generate
 ```
+:::tip Model Name
+if your model within `app` folder, you can just set Model Name only without full namespace
+:::
 And then just answer to the questions and copy the result.
 ## Comming soon
 Include more elements like relationships...

--- a/src/Commands/MakeNovaResource.php
+++ b/src/Commands/MakeNovaResource.php
@@ -48,13 +48,20 @@ class MakeNovaResource extends Command
      */
     public function handle()
     {
-
         $model = $this->ask("What is the name of the Model?");
+        // check if model created as laravel default Models
+        // if true set Fullname space
+        if ( file_exists(app_path($model.'.php')) ) 
+        {
+            $model = '\\App\\'.$model;
+        }
 
-        if( !$this->checkIfModelExists($model)){
+        if ( !$this->checkIfModelExists($model) ) 
+        {
             $this->error("Model {$model} doesn't exist!");
             return;
         }
+
         // Get all fields and reverse the order
         $this->fields = array_reverse(
             $this->tagThem(
@@ -67,12 +74,12 @@ class MakeNovaResource extends Command
             return;
         }
 
-        do{
+        do {
             $selected = $this->choice("Select the field to include",
                 $this->getExistingFields()
             );
             $this->workOnTheCurrentField($selected, $this->popElement($selected));
-        }while($this->confirm('Do you wish to continue?') && count($this->fields) > 0);
+        } while ($this->confirm('Do you wish to continue?') && count($this->fields) > 0);
 
         $this->build();
     }


### PR DESCRIPTION
This feature only valide if model is created inside `app` folder, exactly where laravel model placed by default.
in place of calling model like this  : 
`\App\User`
you can do this : 
`User`